### PR TITLE
Edit extract records to avoid some species having no data

### DIFF
--- a/R/SDMFunctions.R
+++ b/R/SDMFunctions.R
@@ -235,7 +235,7 @@ fitSDM <- function(species, model, climDat, spDat, k, write, outPath) {
 
     pred <- predict(climDat, fullMod, type=type, index = index)
 
-    plot(pred, col = matlab.like(30))
+    raster::plot(pred, col = matlab.like(30))
 
     points(spDat$Presence, pch = "+", cex = 0.4)
 

--- a/R/extract_records.R
+++ b/R/extract_records.R
@@ -64,7 +64,7 @@ if ("data.species" %in% names(dat)) {
     warning("Reached max number of outputs, but more data is available.")
   }
 
-  dat <- dat[-which(is.na(dat$species)),]
+  dat <- dat[!is.na(dat$species),]
 
   if (any(duplicated(dat))) {
     dat <- dat[-which(duplicated(dat)), ]


### PR DESCRIPTION
Minor edit as (before I properly figured out how to run this code) I was getting failures when trying to pull individual species records via extract records. I think this should do the same thing but avoid the error when there are no missing species names caused by creating a logical(0).

Also had issues with the plot in fitSDMs (some conflict with another plotting function causing an error) so I changed to specify the raster package specifically